### PR TITLE
feat: add binary search, set ops with custom equality, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,17 +43,17 @@ const safe  = lo.unwrapOr(i32, null, 42); // 42
 
 ## Function Index
 
-- [Slice Helpers](#slice-helpers) - first, last, nth, firstOr, lastOr, nthOr, initial, tail, drop, dropRight, dropWhile, dropRightWhile, take, takeRight, takeWhile, takeRightWhile, sample, samples
-- [Transform](#transform) - map, mapAlloc, mapIndex, filter, filterAlloc, reject, rejectAlloc, compact, compactAlloc, flatten, flattenAlloc, flatMap, flatMapAlloc, without, forEach, forEachIndex
-- [Aggregate](#aggregate) - reduce, reduceRight, sum, sumBy, product, productBy, mean, meanBy, min, max, minBy, maxBy, minMax, count, countBy, countValues, mode, median, variance, stddev, percentile
+- [Slice Helpers](#slice-helpers) - first, last, nth, firstOr, lastOr, nthOr, initial, tail, drop, dropRight, dropWhile, dropWhileAlloc, dropRightWhile, take, takeRight, takeWhile, takeWhileAlloc, takeRightWhile, sample, samples
+- [Transform](#transform) - map, mapAlloc, mapIndex, filter, filterAlloc, reject, rejectAlloc, compact, compactAlloc, flatten, flattenAlloc, flattenDeep, flatMap, flatMapAlloc, without, forEach, forEachIndex, compactMap, filterMapIter
+- [Aggregate](#aggregate) - reduce, reduceRight, sum, sumBy, product, productBy, mean, meanBy, min, max, minBy, maxBy, minMax, minMaxBy, count, countBy, countValues, mode, median, variance, stddev, sampleVariance, sampleStddev, percentile
 - [Sort & Order](#sort--order) - sortBy, sortByAlloc, sortByField, sortByFieldAlloc, toSortedAlloc, isSorted, equal, reverse, shuffle
-- [Set Operations](#set-operations) - uniq, uniqBy, intersect, union\_, difference, symmetricDifference, findDuplicates, findUniques, elementsMatch
+- [Set Operations](#set-operations) - uniq, uniqBy, intersect, union\_, difference, symmetricDifference, findDuplicates, findUniques, elementsMatch, differenceWith, intersectWith, unionWith
 - [Partition & Group](#partition--group) - partition, groupBy, chunk, window, scan, scanAlloc
 - [Combine](#combine) - concat, splice, interleave, fill, fillRange, repeat, repeatBy, times, timesAlloc
-- [Search](#search) - find, findIndex, findLast, findLastIndex, indexOf, lastIndexOf, contains, containsBy, every, some, none, minIndex, maxIndex
+- [Search](#search) - find, findIndex, findLast, findLastIndex, indexOf, lastIndexOf, contains, containsBy, every, some, none, minIndex, maxIndex, binarySearch, lowerBound, upperBound, sortedIndex, sortedLastIndex
 - [Map Helpers](#map-helpers) - keys, keysAlloc, values, valuesAlloc, entries, entriesAlloc, fromEntries, mapKeys, mapValues, filterMap, filterKeys, filterValues, pickKeys, omitKeys, invert, merge, assign, mapEntries, mapToSlice, valueOr, hasKey, mapCount, keyBy, associate
 - [String Helpers](#string-helpers) - words, wordsAlloc, camelCase, pascalCase, snakeCase, kebabCase, capitalize, lowerFirst, toLower, toUpper, trim, trimStart, trimEnd, startsWith, endsWith, includes, substr, ellipsis, strRepeat, padLeft, padRight, runeLength, randomString, split, splitAlloc, join, replace, replaceAll, chunkString
-- [Math](#math) - sum, mean, median, variance, stddev, percentile, lerp, remap, clamp, inRange, cumSum, cumProd, rangeAlloc, rangeWithStepAlloc
+- [Math](#math) - sum, mean, median, variance, stddev, sampleVariance, sampleStddev, percentile, lerp, remap, clamp, inRange, cumSum, cumProd, rangeAlloc, rangeWithStepAlloc
 - [Tuple Helpers](#tuple-helpers) - zip, zipAlloc, zipWith, unzip, enumerate
 - [Type Helpers](#type-helpers) - isNull, isNotNull, unwrapOr, coalesce, empty, isEmpty, isNotEmpty, ternary, toConst
 - [Types](#types) - Entry, Pair, MinMax, RangeError, PartitionResult, UnzipResult, AssocEntry, and iterator types
@@ -154,6 +154,16 @@ Drop leading elements while the predicate returns true.
 lo.dropWhile(i32, &.{ 1, 2, 3, 4 }, isLessThan3); // &.{ 3, 4 }
 ```
 
+### dropWhileAlloc
+
+Drop leading elements while the predicate returns true. Allocates a copy. Caller owns the returned slice.
+
+```zig
+const result = try lo.dropWhileAlloc(i32, allocator, &.{ 1, 2, 3, 4 }, isLessThan3);
+defer allocator.free(result);
+// result == &.{ 3, 4 }
+```
+
 ### dropRightWhile
 
 Drop trailing elements while the predicate returns true.
@@ -184,6 +194,16 @@ Take leading elements while the predicate returns true.
 
 ```zig
 lo.takeWhile(i32, &.{ 1, 2, 3, 4 }, isLessThan3); // &.{ 1, 2 }
+```
+
+### takeWhileAlloc
+
+Take leading elements while the predicate returns true. Allocates a copy. Caller owns the returned slice.
+
+```zig
+const result = try lo.takeWhileAlloc(i32, allocator, &.{ 1, 2, 3, 4 }, isLessThan3);
+defer allocator.free(result);
+// result == &.{ 1, 2 }
 ```
 
 ### takeRightWhile
@@ -312,12 +332,25 @@ var it = lo.flatten(i32, &data);
 
 ### flattenAlloc
 
-Flatten a slice of slices into an allocated slice. Caller owns the returned slice.
+Flatten a slice of slices into an allocated slice. Counts total elements first, then allocates once. Caller owns the returned slice.
 
 ```zig
-const data = [_][]const i32{ &.{ 1, 2 }, &.{ 3, 4 } };
+const data = [_][]const i32{ &.{ 1, 2 }, &.{ 3, 4, 5 } };
 const result = try lo.flattenAlloc(i32, allocator, &data);
 defer allocator.free(result);
+// result == &.{ 1, 2, 3, 4, 5 }
+```
+
+### flattenDeep
+
+Flatten two levels of nesting (`[][][]T` to `[]T`). Caller owns the returned slice.
+
+```zig
+const inner = [_][]const i32{ &.{ 1, 2 }, &.{ 3 } };
+const outer = [_][]const []const i32{ &inner };
+const result = try lo.flattenDeep(i32, allocator, &outer);
+defer allocator.free(result);
+// result == &.{ 1, 2, 3 }
 ```
 
 ### flatMap
@@ -360,6 +393,33 @@ Invoke a function on each element with its index.
 
 ```zig
 lo.forEachIndex(i32, &.{ 10, 20 }, printWithIndex);
+```
+
+### compactMap
+
+Filter and map in a single pass. The transform returns `?R`; non-null values are collected into an allocated slice. Caller owns the returned slice.
+
+```zig
+const toEvenDoubled = struct {
+    fn f(x: i32) ?i32 {
+        if (@mod(x, 2) == 0) return x * 2;
+        return null;
+    }
+}.f;
+const result = try lo.compactMap(i32, i32, allocator, &.{ 1, 2, 3, 4 }, toEvenDoubled);
+defer allocator.free(result);
+// result == &.{ 4, 8 }
+```
+
+### filterMapIter
+
+Filter and map in a single step. Returns a lazy iterator.
+
+```zig
+var it = lo.filterMapIter(i32, i32, &.{ 1, 2, 3, 4 }, toEvenDoubled);
+it.next(); // 4
+it.next(); // 8
+it.next(); // null
 ```
 
 ---
@@ -416,10 +476,10 @@ lo.productBy(i32, i64, &.{ 2, 3, 4 }, double); // 192
 
 ### mean
 
-Arithmetic mean of a slice. Returns 0.0 for empty slices.
+Arithmetic mean of a slice. Returns null for empty slices.
 
 ```zig
-lo.mean(i32, &.{ 2, 4, 6 }); // 4.0
+lo.mean(i32, &.{ 2, 4, 6 }).?; // 4.0
 ```
 
 ### meanBy
@@ -428,7 +488,7 @@ Arithmetic mean after applying a transform function.
 
 ```zig
 const asF64 = struct { fn f(x: i32) f64 { return @floatFromInt(x); } }.f;
-lo.meanBy(i32, &vals, asF64); // 20.0
+lo.meanBy(i32, &vals, asF64).?; // 20.0
 ```
 
 ### min
@@ -470,6 +530,18 @@ Returns both min and max in a single pass. Null if empty.
 ```zig
 const mm = lo.minMax(i32, &.{ 5, 1, 9, 3 }).?;
 // mm.min_val == 1, mm.max_val == 9
+```
+
+### minMaxBy
+
+Returns both min and max in a single pass according to a custom comparator. Null if empty.
+
+```zig
+const byX = struct { fn f(a: Point, b: Point) std.math.Order {
+    return std.math.order(a.x, b.x);
+} }.f;
+const mm = lo.minMaxBy(Point, &points, byX).?;
+// mm.min_val and mm.max_val
 ```
 
 ### count
@@ -533,6 +605,22 @@ Standard deviation (sqrt of population variance). Returns null for empty slices.
 
 ```zig
 lo.stddev(i32, &.{ 2, 4, 4, 4, 5, 5, 7, 9 }); // 2.0
+```
+
+### sampleVariance
+
+Sample variance with N-1 denominator (Bessel's correction). Returns null for slices with fewer than 2 elements.
+
+```zig
+lo.sampleVariance(i32, &.{ 2, 4, 4, 4, 5, 5, 7, 9 }); // ~4.571
+```
+
+### sampleStddev
+
+Sample standard deviation (sqrt of sample variance). Returns null for slices with fewer than 2 elements.
+
+```zig
+lo.sampleStddev(i32, &.{ 2, 4, 4, 4, 5, 5, 7, 9 }); // ~2.138
 ```
 
 ### percentile
@@ -727,6 +815,37 @@ True if two slices contain the same elements with the same multiplicities, regar
 ```zig
 try lo.elementsMatch(i32, allocator, &.{ 1, 2, 3 }, &.{ 3, 2, 1 }); // true
 try lo.elementsMatch(i32, allocator, &.{ 1, 1, 2 }, &.{ 1, 2, 2 }); // false
+```
+
+### differenceWith
+
+Elements in the first slice but not in the second, using a custom equality predicate.
+
+```zig
+const absEq = struct { fn f(a: i32, b: i32) bool { return @abs(a) == @abs(b); } }.f;
+const d = try lo.differenceWith(i32, allocator, &.{ 1, 2, 3 }, &.{ -2, 4 }, absEq);
+defer allocator.free(d);
+// d == &.{ 1, 3 }
+```
+
+### intersectWith
+
+Elements present in both slices, using a custom equality predicate.
+
+```zig
+const i = try lo.intersectWith(i32, allocator, &.{ 1, -2, 3 }, &.{ 2, 4 }, absEq);
+defer allocator.free(i);
+// i == &.{ -2 }
+```
+
+### unionWith
+
+Unique elements from both slices combined, using a custom equality predicate.
+
+```zig
+const u = try lo.unionWith(i32, allocator, &.{ 1, 2 }, &.{ -2, 3 }, absEq);
+defer allocator.free(u);
+// u == &.{ 1, 2, 3 }
 ```
 
 ---
@@ -1005,6 +1124,51 @@ Returns the index of the maximum element, or null if empty. First occurrence on 
 lo.maxIndex(i32, &.{ 3, 1, 4, 1, 5 }); // 4
 ```
 
+### binarySearch
+
+Binary search for a target in a sorted ascending slice. Returns the index or null. O(log n).
+
+```zig
+lo.binarySearch(i32, &.{ 1, 3, 5, 7, 9 }, 5); // Some(2)
+lo.binarySearch(i32, &.{ 1, 3, 5, 7, 9 }, 4); // null
+```
+
+### lowerBound
+
+Index of the first element >= target in a sorted slice. Returns `slice.len` if all are less.
+
+```zig
+lo.lowerBound(i32, &.{ 1, 3, 5, 7 }, 4); // 2
+lo.lowerBound(i32, &.{ 1, 3, 5, 7 }, 5); // 2
+lo.lowerBound(i32, &.{ 1, 3, 5, 7 }, 9); // 4
+```
+
+### upperBound
+
+Index of the first element > target in a sorted slice. Returns `slice.len` if all are <= target.
+
+```zig
+lo.upperBound(i32, &.{ 1, 3, 5, 7 }, 3); // 2
+lo.upperBound(i32, &.{ 1, 3, 5, 7 }, 4); // 2
+lo.upperBound(i32, &.{ 1, 3, 5, 7 }, 9); // 4
+```
+
+### sortedIndex
+
+Insertion index to maintain sorted order. Equivalent to `lowerBound`.
+
+```zig
+lo.sortedIndex(i32, &.{ 1, 3, 5, 7 }, 4); // 2
+```
+
+### sortedLastIndex
+
+Insertion index after the last occurrence of a value. Equivalent to `upperBound`.
+
+```zig
+lo.sortedLastIndex(i32, &.{ 1, 3, 3, 5 }, 3); // 3
+```
+
 ---
 
 ## Map Helpers
@@ -1123,7 +1287,7 @@ defer result.deinit();
 Keep only entries with the specified keys. Caller owns the returned map.
 
 ```zig
-var result = try lo.pickKeys(u32, u8, allocator, m, &.{ 1, 3 });
+var result = try lo.pickKeys(u32, u8, allocator, &m, &.{ 1, 3 });
 defer result.deinit();
 ```
 
@@ -1185,7 +1349,7 @@ defer allocator.free(result);
 Get a value from the map, or return a default if the key is absent.
 
 ```zig
-lo.valueOr(u32, u8, my_map, 999, 0); // 0 if 999 not in map
+lo.valueOr(u32, u8, &my_map, 999, 0); // 0 if 999 not in map
 ```
 
 ### hasKey
@@ -1193,7 +1357,7 @@ lo.valueOr(u32, u8, my_map, 999, 0); // 0 if 999 not in map
 True if the map contains the given key.
 
 ```zig
-lo.hasKey(u32, u8, m, 1); // true
+lo.hasKey(u32, u8, &m, 1); // true
 ```
 
 ### mapCount
@@ -1201,7 +1365,7 @@ lo.hasKey(u32, u8, m, 1); // true
 Number of entries in the map.
 
 ```zig
-lo.mapCount(u32, u8, m); // 3
+lo.mapCount(u32, u8, &m); // 3
 ```
 
 ### keyBy
@@ -1517,10 +1681,10 @@ lo.sum(i32, &.{ 1, 2, 3, 4 }); // 10
 
 ### mean
 
-Arithmetic mean. Returns 0.0 for empty slices.
+Arithmetic mean. Returns null for empty slices.
 
 ```zig
-lo.mean(i32, &.{ 2, 4, 6 }); // 4.0
+lo.mean(i32, &.{ 2, 4, 6 }).?; // 4.0
 ```
 
 ### median
@@ -1546,6 +1710,22 @@ Standard deviation (sqrt of population variance). Null for empty slices.
 
 ```zig
 lo.stddev(i32, &.{ 2, 4, 4, 4, 5, 5, 7, 9 }); // 2.0
+```
+
+### sampleVariance
+
+Sample variance with N-1 denominator (Bessel's correction). Null for slices with fewer than 2 elements.
+
+```zig
+lo.sampleVariance(i32, &.{ 2, 4, 4, 4, 5, 5, 7, 9 }); // ~4.571
+```
+
+### sampleStddev
+
+Sample standard deviation (sqrt of sample variance). Null for slices with fewer than 2 elements.
+
+```zig
+lo.sampleStddev(i32, &.{ 2, 4, 4, 4, 5, 5, 7, 9 }); // ~2.138
 ```
 
 ### percentile
@@ -1828,6 +2008,7 @@ The following iterator types are returned by their corresponding functions. They
 | `FlatMapIterator` | `flatMap()` |
 | `CompactIterator` | `compact()` |
 | `ChunkIterator` | `chunk()` |
+| `FilterMapIterator` | `filterMapIter()` |
 | `WithoutIterator` | `without()` |
 | `ScanIterator` | `scan()` |
 | `WindowIterator` | `window()` |

--- a/src/lo.zig
+++ b/src/lo.zig
@@ -55,6 +55,9 @@ pub const lerp = math.lerp;
 pub const remap = math.remap;
 pub const cumSum = math.cumSum;
 pub const cumProd = math.cumProd;
+pub const minMaxBy = math.minMaxBy;
+pub const sampleVariance = math.sampleVariance;
+pub const sampleStddev = math.sampleStddev;
 
 // Re-export slice.zig
 pub const first = slice.first;
@@ -73,7 +76,9 @@ pub const dropRightWhile = slice.dropRightWhile;
 pub const take = slice.take;
 pub const takeRight = slice.takeRight;
 pub const takeWhile = slice.takeWhile;
+pub const takeWhileAlloc = slice.takeWhileAlloc;
 pub const takeRightWhile = slice.takeRightWhile;
+pub const dropWhileAlloc = slice.dropWhileAlloc;
 pub const initial = slice.initial;
 pub const tail = slice.tail;
 pub const find = slice.find;
@@ -103,6 +108,7 @@ pub const rejectAlloc = slice.rejectAlloc;
 pub const FlattenIterator = slice.FlattenIterator;
 pub const flatten = slice.flatten;
 pub const flattenAlloc = slice.flattenAlloc;
+pub const flattenDeep = slice.flattenDeep;
 pub const FlatMapIterator = slice.FlatMapIterator;
 pub const flatMap = slice.flatMap;
 pub const flatMapAlloc = slice.flatMapAlloc;
@@ -159,6 +165,18 @@ pub const TimesIterator = slice.TimesIterator;
 pub const times = slice.times;
 pub const timesAlloc = slice.timesAlloc;
 pub const toSortedAlloc = slice.toSortedAlloc;
+pub const binarySearch = slice.binarySearch;
+pub const binarySearchBy = slice.binarySearchBy;
+pub const lowerBound = slice.lowerBound;
+pub const upperBound = slice.upperBound;
+pub const sortedIndex = slice.sortedIndex;
+pub const sortedLastIndex = slice.sortedLastIndex;
+pub const differenceWith = slice.differenceWith;
+pub const intersectWith = slice.intersectWith;
+pub const unionWith = slice.unionWith;
+pub const compactMap = slice.compactMap;
+pub const FilterMapIterator = slice.FilterMapIterator;
+pub const filterMapIter = slice.filterMapIter;
 
 // Re-export map.zig
 pub const Entry = hash_map.Entry;

--- a/src/map.zig
+++ b/src/map.zig
@@ -270,14 +270,14 @@ pub fn filterMap(
 /// Caller owns the returned map.
 ///
 /// ```zig
-/// var result = try lo.pickKeys(u32, u8, allocator, m, &.{ 1, 3 });
+/// var result = try lo.pickKeys(u32, u8, allocator, &m, &.{ 1, 3 });
 /// defer result.deinit();
 /// ```
 pub fn pickKeys(
     comptime K: type,
     comptime V: type,
     allocator: Allocator,
-    hash_map: std.AutoHashMap(K, V),
+    hash_map: *const std.AutoHashMap(K, V),
     pick: []const K,
 ) Allocator.Error!std.AutoHashMap(K, V) {
     var result = std.AutoHashMap(K, V).init(allocator);
@@ -361,12 +361,12 @@ pub fn merge(
 /// Get a value from the map, or return a default if the key is absent.
 ///
 /// ```zig
-/// lo.valueOr(u32, u8, my_map, 999, 0); // 0 if 999 not in map
+/// lo.valueOr(u32, u8, &my_map, 999, 0); // 0 if 999 not in map
 /// ```
 pub fn valueOr(
     comptime K: type,
     comptime V: type,
-    hash_map: std.AutoHashMap(K, V),
+    hash_map: *const std.AutoHashMap(K, V),
     key: K,
     default: V,
 ) V {
@@ -376,12 +376,12 @@ pub fn valueOr(
 /// True if the map contains the given key.
 ///
 /// ```zig
-/// lo.hasKey(u32, u8, m, 1); // true
+/// lo.hasKey(u32, u8, &m, 1); // true
 /// ```
 pub fn hasKey(
     comptime K: type,
     comptime V: type,
-    hash_map: std.AutoHashMap(K, V),
+    hash_map: *const std.AutoHashMap(K, V),
     key: K,
 ) bool {
     return hash_map.contains(key);
@@ -390,12 +390,12 @@ pub fn hasKey(
 /// Number of entries in the map.
 ///
 /// ```zig
-/// lo.mapCount(u32, u8, m); // 3
+/// lo.mapCount(u32, u8, &m); // 3
 /// ```
 pub fn mapCount(
     comptime K: type,
     comptime V: type,
-    hash_map: std.AutoHashMap(K, V),
+    hash_map: *const std.AutoHashMap(K, V),
 ) usize {
     return hash_map.count();
 }
@@ -811,7 +811,7 @@ test "filterMap: no matches" {
 test "pickKeys: keeps specified keys" {
     var m = try makeTestMap(std.testing.allocator);
     defer m.deinit();
-    var result = try pickKeys(u32, u8, std.testing.allocator, m, &.{ 1, 3 });
+    var result = try pickKeys(u32, u8, std.testing.allocator, &m, &.{ 1, 3 });
     defer result.deinit();
     try std.testing.expectEqual(@as(usize, 2), result.count());
     try std.testing.expectEqual(@as(u8, 'a'), result.get(1).?);
@@ -821,7 +821,7 @@ test "pickKeys: keeps specified keys" {
 test "pickKeys: single key" {
     var m = try makeTestMap(std.testing.allocator);
     defer m.deinit();
-    var result = try pickKeys(u32, u8, std.testing.allocator, m, &.{2});
+    var result = try pickKeys(u32, u8, std.testing.allocator, &m, &.{2});
     defer result.deinit();
     try std.testing.expectEqual(@as(usize, 1), result.count());
     try std.testing.expectEqual(@as(u8, 'b'), result.get(2).?);
@@ -830,7 +830,7 @@ test "pickKeys: single key" {
 test "pickKeys: keys not in map" {
     var m = try makeTestMap(std.testing.allocator);
     defer m.deinit();
-    var result = try pickKeys(u32, u8, std.testing.allocator, m, &.{ 99, 100 });
+    var result = try pickKeys(u32, u8, std.testing.allocator, &m, &.{ 99, 100 });
     defer result.deinit();
     try std.testing.expectEqual(@as(usize, 0), result.count());
 }
@@ -838,7 +838,7 @@ test "pickKeys: keys not in map" {
 test "pickKeys: empty pick list" {
     var m = try makeTestMap(std.testing.allocator);
     defer m.deinit();
-    var result = try pickKeys(u32, u8, std.testing.allocator, m, &.{});
+    var result = try pickKeys(u32, u8, std.testing.allocator, &m, &.{});
     defer result.deinit();
     try std.testing.expectEqual(@as(usize, 0), result.count());
 }
@@ -967,56 +967,56 @@ test "merge: empty source" {
 test "valueOr: returns value when key exists" {
     var m = try makeTestMap(std.testing.allocator);
     defer m.deinit();
-    try std.testing.expectEqual(@as(u8, 'a'), valueOr(u32, u8, m, 1, 'z'));
+    try std.testing.expectEqual(@as(u8, 'a'), valueOr(u32, u8, &m, 1, 'z'));
 }
 
 test "valueOr: returns default when key absent" {
     var m = try makeTestMap(std.testing.allocator);
     defer m.deinit();
-    try std.testing.expectEqual(@as(u8, 'z'), valueOr(u32, u8, m, 99, 'z'));
+    try std.testing.expectEqual(@as(u8, 'z'), valueOr(u32, u8, &m, 99, 'z'));
 }
 
 test "valueOr: empty map returns default" {
     var m = std.AutoHashMap(u32, u8).init(std.testing.allocator);
     defer m.deinit();
-    try std.testing.expectEqual(@as(u8, 'x'), valueOr(u32, u8, m, 1, 'x'));
+    try std.testing.expectEqual(@as(u8, 'x'), valueOr(u32, u8, &m, 1, 'x'));
 }
 
 test "hasKey: key exists" {
     var m = try makeTestMap(std.testing.allocator);
     defer m.deinit();
-    try std.testing.expect(hasKey(u32, u8, m, 1));
+    try std.testing.expect(hasKey(u32, u8, &m, 1));
 }
 
 test "hasKey: key absent" {
     var m = try makeTestMap(std.testing.allocator);
     defer m.deinit();
-    try std.testing.expect(!hasKey(u32, u8, m, 99));
+    try std.testing.expect(!hasKey(u32, u8, &m, 99));
 }
 
 test "hasKey: empty map" {
     var m = std.AutoHashMap(u32, u8).init(std.testing.allocator);
     defer m.deinit();
-    try std.testing.expect(!hasKey(u32, u8, m, 1));
+    try std.testing.expect(!hasKey(u32, u8, &m, 1));
 }
 
 test "mapCount: returns entry count" {
     var m = try makeTestMap(std.testing.allocator);
     defer m.deinit();
-    try std.testing.expectEqual(@as(usize, 3), mapCount(u32, u8, m));
+    try std.testing.expectEqual(@as(usize, 3), mapCount(u32, u8, &m));
 }
 
 test "mapCount: empty map" {
     var m = std.AutoHashMap(u32, u8).init(std.testing.allocator);
     defer m.deinit();
-    try std.testing.expectEqual(@as(usize, 0), mapCount(u32, u8, m));
+    try std.testing.expectEqual(@as(usize, 0), mapCount(u32, u8, &m));
 }
 
 test "mapCount: single entry" {
     var m = std.AutoHashMap(u32, u8).init(std.testing.allocator);
     defer m.deinit();
     try m.put(1, 'a');
-    try std.testing.expectEqual(@as(usize, 1), mapCount(u32, u8, m));
+    try std.testing.expectEqual(@as(usize, 1), mapCount(u32, u8, &m));
 }
 
 // ── mapEntries tests ──────────────────────────────────────────────────

--- a/src/math.zig
+++ b/src/math.zig
@@ -66,13 +66,13 @@ pub fn productBy(
     return acc;
 }
 
-/// Arithmetic mean of a slice. Returns 0.0 for empty slices.
+/// Arithmetic mean of a slice. Returns null for empty slices.
 ///
 /// ```zig
-/// lo.mean(i32, &.{ 2, 4, 6 }); // 4.0
+/// lo.mean(i32, &.{ 2, 4, 6 }).?; // 4.0
 /// ```
-pub fn mean(comptime T: type, slice: []const T) f64 {
-    if (slice.len == 0) return 0.0;
+pub fn mean(comptime T: type, slice: []const T) ?f64 {
+    if (slice.len == 0) return null;
     var acc: f64 = 0.0;
     for (slice) |v| {
         acc += toF64(T, v);
@@ -81,18 +81,19 @@ pub fn mean(comptime T: type, slice: []const T) f64 {
 }
 
 /// Arithmetic mean after applying a transform function.
+/// Returns null for empty slices.
 ///
 /// ```zig
 /// const vals = [_]i32{ 10, 20, 30 };
 /// const asF64 = struct { fn f(x: i32) f64 { return @floatFromInt(x); } }.f;
-/// lo.meanBy(i32, &vals, asF64); // 20.0
+/// lo.meanBy(i32, &vals, asF64).?; // 20.0
 /// ```
 pub fn meanBy(
     comptime T: type,
     slice: []const T,
     transform: *const fn (T) f64,
-) f64 {
-    if (slice.len == 0) return 0.0;
+) ?f64 {
+    if (slice.len == 0) return null;
     var acc: f64 = 0.0;
     for (slice) |v| {
         acc += transform(v);
@@ -191,6 +192,30 @@ pub fn MinMax(comptime T: type) type {
     };
 }
 
+/// Returns both min and max in a single pass according to a custom comparator.
+/// Null if empty.
+///
+/// ```zig
+/// const mm = lo.minMaxBy(Point, &points, compareByX).?;
+/// // mm.min_val, mm.max_val
+/// ```
+pub fn minMaxBy(
+    comptime T: type,
+    slice: []const T,
+    comparator: *const fn (T, T) std.math.Order,
+) ?MinMax(T) {
+    if (slice.len == 0) return null;
+    var result = MinMax(T){
+        .min_val = slice[0],
+        .max_val = slice[0],
+    };
+    for (slice[1..]) |v| {
+        if (comparator(v, result.min_val) == .lt) result.min_val = v;
+        if (comparator(v, result.max_val) == .gt) result.max_val = v;
+    }
+    return result;
+}
+
 /// Clamp a value to the range [lo, hi].
 ///
 /// ```zig
@@ -233,11 +258,16 @@ pub fn rangeAlloc(
 
 /// Allocate a slice containing values from start to end (exclusive)
 /// with the given step. Returns error.InvalidArgument if step is 0.
+/// Supports negative steps for descending ranges.
 ///
 /// ```zig
 /// const r = try lo.rangeWithStepAlloc(i32, allocator, 0, 10, 3);
 /// defer allocator.free(r);
 /// // r == .{ 0, 3, 6, 9 }
+///
+/// const desc = try lo.rangeWithStepAlloc(i32, allocator, 10, 0, -2);
+/// defer allocator.free(desc);
+/// // desc == .{ 10, 8, 6, 4, 2 }
 /// ```
 pub fn rangeWithStepAlloc(
     comptime T: type,
@@ -247,19 +277,31 @@ pub fn rangeWithStepAlloc(
     step: T,
 ) RangeError![]T {
     if (step == 0) return error.InvalidArgument;
-    if (start >= end) {
-        return allocator.alloc(T, 0);
+    if (step > 0) {
+        if (start >= end) return allocator.alloc(T, 0);
+        const span: usize = @intCast(end - start);
+        const s: usize = @intCast(step);
+        const len = (span + s - 1) / s;
+        const result = try allocator.alloc(T, len);
+        var v = start;
+        for (result) |*slot| {
+            slot.* = v;
+            v += step;
+        }
+        return result;
+    } else {
+        if (start <= end) return allocator.alloc(T, 0);
+        const span: usize = @intCast(start - end);
+        const s: usize = @intCast(-step);
+        const len = (span + s - 1) / s;
+        const result = try allocator.alloc(T, len);
+        var v = start;
+        for (result) |*slot| {
+            slot.* = v;
+            v += step;
+        }
+        return result;
     }
-    const span: usize = @intCast(end - start);
-    const s: usize = @intCast(step);
-    const len = (span + s - 1) / s;
-    const result = try allocator.alloc(T, len);
-    var v = start;
-    for (result) |*slot| {
-        slot.* = v;
-        v += step;
-    }
-    return result;
 }
 
 /// Error set for `rangeWithStepAlloc`. Includes `InvalidArgument` for zero step.
@@ -301,7 +343,7 @@ pub fn mode(
         const key = entry.key_ptr.*;
         if (count_val > best_count or
             (count_val == best_count and (best == null or
-            std.math.order(key, best.?) == .lt)))
+                std.math.order(key, best.?) == .lt)))
         {
             best_count = count_val;
             best = key;
@@ -376,7 +418,7 @@ pub fn percentile(comptime T: type, allocator: Allocator, slice: []const T, p: f
 pub fn variance(comptime T: type, slice: []const T) ?f64 {
     if (slice.len == 0) return null;
 
-    const m = mean(T, slice);
+    const m = mean(T, slice).?;
     var acc: f64 = 0.0;
     for (slice) |v| {
         const diff = toF64(T, v) - m;
@@ -393,6 +435,35 @@ pub fn variance(comptime T: type, slice: []const T) ?f64 {
 /// ```
 pub fn stddev(comptime T: type, slice: []const T) ?f64 {
     const v = variance(T, slice) orelse return null;
+    return @sqrt(v);
+}
+
+/// Sample variance of a numeric slice (N-1 denominator, Bessel's correction).
+/// Returns null for slices with fewer than 2 elements.
+///
+/// ```zig
+/// lo.sampleVariance(i32, &.{ 2, 4, 4, 4, 5, 5, 7, 9 }); // ~4.571
+/// ```
+pub fn sampleVariance(comptime T: type, slice: []const T) ?f64 {
+    if (slice.len < 2) return null;
+
+    const m = mean(T, slice).?;
+    var acc: f64 = 0.0;
+    for (slice) |v| {
+        const diff = toF64(T, v) - m;
+        acc += diff * diff;
+    }
+    return acc / @as(f64, @floatFromInt(slice.len - 1));
+}
+
+/// Sample standard deviation (sqrt of sample variance with N-1 denominator).
+/// Returns null for slices with fewer than 2 elements.
+///
+/// ```zig
+/// lo.sampleStddev(i32, &.{ 2, 4, 4, 4, 5, 5, 7, 9 }); // ~2.138
+/// ```
+pub fn sampleStddev(comptime T: type, slice: []const T) ?f64 {
+    const v = sampleVariance(T, slice) orelse return null;
     return @sqrt(v);
 }
 
@@ -602,19 +673,19 @@ test "productBy: single element" {
 }
 
 test "mean: integers" {
-    try std.testing.expectEqual(@as(f64, 4.0), mean(i32, &.{ 2, 4, 6 }));
+    try std.testing.expectEqual(@as(f64, 4.0), mean(i32, &.{ 2, 4, 6 }).?);
 }
 
-test "mean: empty slice returns 0" {
-    try std.testing.expectEqual(@as(f64, 0.0), mean(i32, &.{}));
+test "mean: empty slice returns null" {
+    try std.testing.expectEqual(@as(?f64, null), mean(i32, &.{}));
 }
 
 test "mean: single element" {
-    try std.testing.expectEqual(@as(f64, 5.0), mean(i32, &.{5}));
+    try std.testing.expectEqual(@as(f64, 5.0), mean(i32, &.{5}).?);
 }
 
 test "mean: floats" {
-    try std.testing.expectEqual(@as(f64, 2.5), mean(f64, &.{ 1.0, 2.0, 3.0, 4.0 }));
+    try std.testing.expectEqual(@as(f64, 2.5), mean(f64, &.{ 1.0, 2.0, 3.0, 4.0 }).?);
 }
 
 test "meanBy: transform then average" {
@@ -625,17 +696,17 @@ test "meanBy: transform then average" {
     }.f;
     try std.testing.expectEqual(
         @as(f64, 2.0),
-        meanBy(i32, &.{ 1, 2, 3 }, asF64),
+        meanBy(i32, &.{ 1, 2, 3 }, asF64).?,
     );
 }
 
-test "meanBy: empty slice returns 0" {
+test "meanBy: empty slice returns null" {
     const asF64 = struct {
         fn f(x: i32) f64 {
             return @floatFromInt(x);
         }
     }.f;
-    try std.testing.expectEqual(@as(f64, 0.0), meanBy(i32, &.{}, asF64));
+    try std.testing.expectEqual(@as(?f64, null), meanBy(i32, &.{}, asF64));
 }
 
 test "meanBy: single element" {
@@ -644,7 +715,7 @@ test "meanBy: single element" {
             return @as(f64, @floatFromInt(x)) * 2.0;
         }
     }.f;
-    try std.testing.expectEqual(@as(f64, 10.0), meanBy(i32, &.{5}, doubled));
+    try std.testing.expectEqual(@as(f64, 10.0), meanBy(i32, &.{5}, doubled).?);
 }
 
 test "min: finds minimum" {
@@ -772,6 +843,43 @@ test "minMax: two elements" {
     try std.testing.expectEqual(@as(i32, 10), result.max_val);
 }
 
+test "minMaxBy: custom comparator" {
+    const Point = struct { x: i32, y: i32 };
+    const byX = struct {
+        fn f(a: Point, b: Point) std.math.Order {
+            return std.math.order(a.x, b.x);
+        }
+    }.f;
+    const pts = [_]Point{
+        .{ .x = 3, .y = 0 },
+        .{ .x = 1, .y = 0 },
+        .{ .x = 2, .y = 0 },
+    };
+    const result = minMaxBy(Point, &pts, byX).?;
+    try std.testing.expectEqual(@as(i32, 1), result.min_val.x);
+    try std.testing.expectEqual(@as(i32, 3), result.max_val.x);
+}
+
+test "minMaxBy: empty returns null" {
+    const cmp = struct {
+        fn f(a: i32, b: i32) std.math.Order {
+            return std.math.order(a, b);
+        }
+    }.f;
+    try std.testing.expectEqual(@as(?MinMax(i32), null), minMaxBy(i32, &.{}, cmp));
+}
+
+test "minMaxBy: single element" {
+    const cmp = struct {
+        fn f(a: i32, b: i32) std.math.Order {
+            return std.math.order(a, b);
+        }
+    }.f;
+    const result = minMaxBy(i32, &.{42}, cmp).?;
+    try std.testing.expectEqual(@as(i32, 42), result.min_val);
+    try std.testing.expectEqual(@as(i32, 42), result.max_val);
+}
+
 test "clamp: within range unchanged" {
     try std.testing.expectEqual(@as(i32, 5), clamp(i32, 5, 0, 10));
 }
@@ -858,6 +966,42 @@ test "rangeWithStepAlloc: step larger than range" {
     );
     defer std.testing.allocator.free(r);
     try std.testing.expectEqualSlices(i32, &.{0}, r);
+}
+
+test "rangeWithStepAlloc: negative step descending" {
+    const r = try rangeWithStepAlloc(
+        i32,
+        std.testing.allocator,
+        10,
+        0,
+        -2,
+    );
+    defer std.testing.allocator.free(r);
+    try std.testing.expectEqualSlices(i32, &.{ 10, 8, 6, 4, 2 }, r);
+}
+
+test "rangeWithStepAlloc: negative step -1" {
+    const r = try rangeWithStepAlloc(
+        i32,
+        std.testing.allocator,
+        5,
+        2,
+        -1,
+    );
+    defer std.testing.allocator.free(r);
+    try std.testing.expectEqualSlices(i32, &.{ 5, 4, 3 }, r);
+}
+
+test "rangeWithStepAlloc: negative step start <= end returns empty" {
+    const r = try rangeWithStepAlloc(
+        i32,
+        std.testing.allocator,
+        0,
+        5,
+        -1,
+    );
+    defer std.testing.allocator.free(r);
+    try std.testing.expectEqual(@as(usize, 0), r.len);
 }
 
 test "mode: finds most frequent" {
@@ -1032,6 +1176,61 @@ test "stddev: is sqrt of variance" {
     const data = [_]i32{ 1, 3, 5, 7, 9 };
     const v = variance(i32, &data).?;
     const s = stddev(i32, &data).?;
+    try std.testing.expectApproxEqAbs(@sqrt(v), s, 1e-10);
+}
+
+// sampleVariance tests
+
+test "sampleVariance: empty slice returns null" {
+    const result = sampleVariance(i32, &.{});
+    try std.testing.expectEqual(@as(?f64, null), result);
+}
+
+test "sampleVariance: single element returns null" {
+    const result = sampleVariance(i32, &.{5});
+    try std.testing.expectEqual(@as(?f64, null), result);
+}
+
+test "sampleVariance: two elements" {
+    // {1, 3}: mean=2, sum_sq_diff = 1+1 = 2, sample_var = 2/1 = 2.0
+    const result = sampleVariance(i32, &.{ 1, 3 }).?;
+    try std.testing.expectApproxEqAbs(@as(f64, 2.0), result, 1e-10);
+}
+
+test "sampleVariance: known value" {
+    // {2,4,4,4,5,5,7,9}: mean=5, sum_sq_diff=32, sample_var = 32/7 ≈ 4.571429
+    const result = sampleVariance(i32, &.{ 2, 4, 4, 4, 5, 5, 7, 9 }).?;
+    try std.testing.expectApproxEqAbs(@as(f64, 32.0 / 7.0), result, 1e-10);
+}
+
+test "sampleVariance: all same returns 0.0" {
+    const result = sampleVariance(i32, &.{ 7, 7 }).?;
+    try std.testing.expectApproxEqAbs(@as(f64, 0.0), result, 1e-10);
+}
+
+test "sampleVariance: greater than population variance" {
+    const data = [_]i32{ 1, 2, 3, 4, 5 };
+    const pop = variance(i32, &data).?;
+    const sample = sampleVariance(i32, &data).?;
+    try std.testing.expect(sample > pop);
+}
+
+// sampleStddev tests
+
+test "sampleStddev: empty slice returns null" {
+    const result = sampleStddev(i32, &.{});
+    try std.testing.expectEqual(@as(?f64, null), result);
+}
+
+test "sampleStddev: single element returns null" {
+    const result = sampleStddev(i32, &.{5});
+    try std.testing.expectEqual(@as(?f64, null), result);
+}
+
+test "sampleStddev: is sqrt of sample variance" {
+    const data = [_]i32{ 2, 4, 4, 4, 5, 5, 7, 9 };
+    const v = sampleVariance(i32, &data).?;
+    const s = sampleStddev(i32, &data).?;
     try std.testing.expectApproxEqAbs(@sqrt(v), s, 1e-10);
 }
 

--- a/src/slice.zig
+++ b/src/slice.zig
@@ -251,6 +251,42 @@ pub fn takeRightWhile(
     return slice[len..];
 }
 
+/// Take leading elements while the predicate returns true. Allocates a copy.
+/// Caller owns the returned slice.
+///
+/// ```zig
+/// const result = try lo.takeWhileAlloc(i32, allocator, &.{1,2,3,4}, isLt3);
+/// defer allocator.free(result);
+/// // result == &.{ 1, 2 }
+/// ```
+pub fn takeWhileAlloc(
+    comptime T: type,
+    allocator: Allocator,
+    slice: []const T,
+    predicate: *const fn (T) bool,
+) Allocator.Error![]T {
+    const sub = takeWhile(T, slice, predicate);
+    return allocator.dupe(T, sub);
+}
+
+/// Drop leading elements while the predicate returns true. Allocates a copy.
+/// Caller owns the returned slice.
+///
+/// ```zig
+/// const result = try lo.dropWhileAlloc(i32, allocator, &.{1,2,3,4}, isLt3);
+/// defer allocator.free(result);
+/// // result == &.{ 3, 4 }
+/// ```
+pub fn dropWhileAlloc(
+    comptime T: type,
+    allocator: Allocator,
+    slice: []const T,
+    predicate: *const fn (T) bool,
+) Allocator.Error![]T {
+    const sub = dropWhile(T, slice, predicate);
+    return allocator.dupe(T, sub);
+}
+
 /// All elements except the last. Empty slice if input is empty.
 ///
 /// ```zig
@@ -661,6 +697,7 @@ pub fn filter(
 }
 
 /// Keep elements matching the predicate, collected into an allocated slice.
+/// Two-pass: pre-counts matches, allocates once, then fills.
 /// Caller owns the returned slice.
 ///
 /// ```zig
@@ -673,8 +710,19 @@ pub fn filterAlloc(
     slice: []const T,
     predicate: *const fn (T) bool,
 ) Allocator.Error![]T {
-    var it = filter(T, slice, predicate);
-    return it.collect(allocator);
+    var match_count: usize = 0;
+    for (slice) |item| {
+        if (predicate(item)) match_count += 1;
+    }
+    const result = try allocator.alloc(T, match_count);
+    var idx: usize = 0;
+    for (slice) |item| {
+        if (predicate(item)) {
+            result[idx] = item;
+            idx += 1;
+        }
+    }
+    return result;
 }
 
 /// Lazy iterator that skips elements matching a predicate.
@@ -723,6 +771,7 @@ pub fn reject(
 }
 
 /// Remove elements matching the predicate, collected into an allocated slice.
+/// Two-pass: pre-counts non-matches, allocates once, then fills.
 /// Caller owns the returned slice.
 ///
 /// ```zig
@@ -735,8 +784,19 @@ pub fn rejectAlloc(
     slice: []const T,
     predicate: *const fn (T) bool,
 ) Allocator.Error![]T {
-    var it = reject(T, slice, predicate);
-    return it.collect(allocator);
+    var keep_count: usize = 0;
+    for (slice) |item| {
+        if (!predicate(item)) keep_count += 1;
+    }
+    const result = try allocator.alloc(T, keep_count);
+    var idx: usize = 0;
+    for (slice) |item| {
+        if (!predicate(item)) {
+            result[idx] = item;
+            idx += 1;
+        }
+    }
+    return result;
 }
 
 /// Lazy iterator that flattens nested slices.
@@ -789,6 +849,7 @@ pub fn flatten(
 }
 
 /// Flatten a slice of slices into an allocated slice.
+/// Counts total elements first, then allocates once.
 /// Caller owns the returned slice.
 ///
 /// ```zig
@@ -801,8 +862,44 @@ pub fn flattenAlloc(
     allocator: Allocator,
     slices: []const []const T,
 ) Allocator.Error![]T {
-    var it = flatten(T, slices);
-    return it.collect(allocator);
+    var total: usize = 0;
+    for (slices) |s| total += s.len;
+    const result = try allocator.alloc(T, total);
+    var offset: usize = 0;
+    for (slices) |s| {
+        @memcpy(result[offset..][0..s.len], s);
+        offset += s.len;
+    }
+    return result;
+}
+
+/// Flatten two levels of nesting: `[][][]T` → allocated `[]T`.
+///
+/// ```zig
+/// const inner = [_][]const i32{ &.{1,2}, &.{3} };
+/// const outer = [_][]const []const i32{ &inner };
+/// const result = try lo.flattenDeep(i32, allocator, &outer);
+/// defer allocator.free(result);
+/// // result == &.{1, 2, 3}
+/// ```
+pub fn flattenDeep(
+    comptime T: type,
+    allocator: Allocator,
+    outer: []const []const []const T,
+) Allocator.Error![]T {
+    var total: usize = 0;
+    for (outer) |mid| {
+        for (mid) |inner| total += inner.len;
+    }
+    const result = try allocator.alloc(T, total);
+    var offset: usize = 0;
+    for (outer) |mid| {
+        for (mid) |inner| {
+            @memcpy(result[offset..][0..inner.len], inner);
+            offset += inner.len;
+        }
+    }
+    return result;
 }
 
 /// Lazy iterator that maps and flattens.
@@ -962,6 +1059,7 @@ pub fn ChunkIterator(comptime T: type) type {
         const Self = @This();
 
         pub fn next(self: *Self) ?[]const T {
+            if (self.size == 0) return null;
             if (self.index >= self.slice.len) return null;
             const end = @min(self.index + self.size, self.slice.len);
             const result = self.slice[self.index..end];
@@ -1176,6 +1274,7 @@ pub fn partition(
 // Set operations.
 
 /// Elements present in both slices. Order follows the first slice.
+/// Result is bounded by a.len; uses a single allocation + shrink.
 ///
 /// ```zig
 /// const i = try lo.intersect(i32, allocator, &.{1,2,3}, &.{2,3,4});
@@ -1193,14 +1292,16 @@ pub fn intersect(
     for (b) |item| {
         try set.put(item, {});
     }
-    var list = std.ArrayList(T){};
-    errdefer list.deinit(allocator);
+    var buf = try allocator.alloc(T, a.len);
+    errdefer allocator.free(buf);
+    var out: usize = 0;
     for (a) |item| {
         if (set.contains(item)) {
-            try list.append(allocator, item);
+            buf[out] = item;
+            out += 1;
         }
     }
-    return list.toOwnedSlice(allocator);
+    return allocator.realloc(buf, out);
 }
 
 /// Unique elements from both slices combined.
@@ -1236,6 +1337,7 @@ pub fn union_(
 }
 
 /// Elements in the first slice but not in the second.
+/// Result is bounded by a.len; uses a single allocation + shrink.
 ///
 /// ```zig
 /// const d = try lo.difference(i32, allocator, &.{1,2,3}, &.{2,4});
@@ -1250,17 +1352,17 @@ pub fn difference(
 ) Allocator.Error![]T {
     var set = std.AutoHashMap(T, void).init(allocator);
     defer set.deinit();
-    for (b) |item| {
-        try set.put(item, {});
-    }
-    var list = std.ArrayList(T){};
-    errdefer list.deinit(allocator);
+    for (b) |item| try set.put(item, {});
+    var buf = try allocator.alloc(T, a.len);
+    errdefer allocator.free(buf);
+    var out: usize = 0;
     for (a) |item| {
         if (!set.contains(item)) {
-            try list.append(allocator, item);
+            buf[out] = item;
+            out += 1;
         }
     }
-    return list.toOwnedSlice(allocator);
+    return allocator.realloc(buf, out);
 }
 
 /// Elements in either slice but not in both.
@@ -1461,7 +1563,7 @@ pub fn sortBy(comptime T: type, comptime K: type, items: []T, key_fn: *const fn 
     const ctx = Context{ .key = key_fn };
     std.sort.block(T, items, ctx, struct {
         fn lessThan(c: Context, a: T, b: T) bool {
-            return std.math.order(c.key(a), c.key(b)) == .lt;
+            return c.key(a) < c.key(b);
         }
     }.lessThan);
 }
@@ -1503,7 +1605,7 @@ pub fn sortByField(comptime T: type, items: []T, comptime field: std.meta.FieldE
     const field_name = @tagName(field);
     std.sort.block(T, items, {}, struct {
         fn lessThan(_: void, a: T, b: T) bool {
-            return std.math.order(@field(a, field_name), @field(b, field_name)) == .lt;
+            return @field(a, field_name) < @field(b, field_name);
         }
     }.lessThan);
 }
@@ -1648,7 +1750,7 @@ pub fn splice(comptime T: type, allocator: Allocator, items: []const T, index: u
     const result = try allocator.alloc(T, items.len + new_elements.len);
     @memcpy(result[0..idx], items[0..idx]);
     @memcpy(result[idx..][0..new_elements.len], new_elements);
-    @memcpy(result[idx + new_elements.len ..][0..items.len - idx], items[idx..]);
+    @memcpy(result[idx + new_elements.len ..][0 .. items.len - idx], items[idx..]);
     return result;
 }
 
@@ -1767,29 +1869,17 @@ pub fn findDuplicates(
     allocator: Allocator,
     items: []const T,
 ) Allocator.Error![]T {
-    // Pass 1: count occurrences.
-    var counts = std.AutoHashMap(T, usize).init(allocator);
-    defer counts.deinit();
-    for (items) |item| {
-        const entry = try counts.getOrPut(item);
-        if (entry.found_existing) {
-            entry.value_ptr.* += 1;
-        } else {
-            entry.value_ptr.* = 1;
-        }
-    }
-    // Pass 2: collect first occurrence of each element with count > 1.
-    var seen = std.AutoHashMap(T, void).init(allocator);
-    defer seen.deinit();
+    var state = std.AutoHashMap(T, u8).init(allocator);
+    defer state.deinit();
     var list = std.ArrayList(T){};
     errdefer list.deinit(allocator);
     for (items) |item| {
-        const c = counts.get(item) orelse continue;
-        if (c > 1) {
-            const gop = try seen.getOrPut(item);
-            if (!gop.found_existing) {
-                try list.append(allocator, item);
-            }
+        const gop = try state.getOrPut(item);
+        if (!gop.found_existing) {
+            gop.value_ptr.* = 0;
+        } else if (gop.value_ptr.* == 0) {
+            gop.value_ptr.* = 1;
+            try list.append(allocator, item);
         }
     }
     return list.toOwnedSlice(allocator);
@@ -1810,24 +1900,21 @@ pub fn findUniques(
     allocator: Allocator,
     items: []const T,
 ) Allocator.Error![]T {
-    // Pass 1: count occurrences.
-    var counts = std.AutoHashMap(T, usize).init(allocator);
-    defer counts.deinit();
+    var state = std.AutoHashMap(T, u8).init(allocator);
+    defer state.deinit();
     for (items) |item| {
-        const entry = try counts.getOrPut(item);
-        if (entry.found_existing) {
-            entry.value_ptr.* += 1;
+        const gop = try state.getOrPut(item);
+        if (!gop.found_existing) {
+            gop.value_ptr.* = 0;
         } else {
-            entry.value_ptr.* = 1;
+            gop.value_ptr.* = 1;
         }
     }
-    // Pass 2: collect elements with count == 1 in original order.
     var list = std.ArrayList(T){};
     errdefer list.deinit(allocator);
     for (items) |item| {
-        const c = counts.get(item) orelse continue;
-        if (c == 1) {
-            try list.append(allocator, item);
+        if (state.get(item)) |v| {
+            if (v == 0) try list.append(allocator, item);
         }
     }
     return list.toOwnedSlice(allocator);
@@ -1986,19 +2073,18 @@ pub fn window(
 pub fn InterleaveIterator(comptime T: type) type {
     return struct {
         slices: []const []const T,
+        max_len: usize,
         cursor: usize = 0,
 
         const Self = @This();
 
         pub fn next(self: *Self) ?T {
             if (self.slices.len == 0) return null;
-            var max_len: usize = 0;
-            for (self.slices) |s| max_len = @max(max_len, s.len);
 
             while (true) {
                 const round = self.cursor / self.slices.len;
                 const slot = self.cursor % self.slices.len;
-                if (round >= max_len) return null;
+                if (round >= self.max_len) return null;
                 self.cursor += 1;
                 if (round < self.slices[slot].len) {
                     return self.slices[slot][round];
@@ -2027,7 +2113,9 @@ pub fn interleave(
     comptime T: type,
     slices: []const []const T,
 ) InterleaveIterator(T) {
-    return .{ .slices = slices };
+    var max_len: usize = 0;
+    for (slices) |s| max_len = @max(max_len, s.len);
+    return .{ .slices = slices, .max_len = max_len };
 }
 
 // Access with defaults.
@@ -2144,6 +2232,273 @@ pub fn maxIndex(comptime T: type, slice_: []const T) ?usize {
 
 fn eql(comptime T: type, a: T, b: T) bool {
     return std.meta.eql(a, b);
+}
+
+// Binary search.
+
+/// Binary search for `target` in a sorted slice using natural ordering.
+/// Returns the index of the target, or null if not found.
+/// The slice must be sorted in ascending order.
+///
+/// ```zig
+/// lo.binarySearch(i32, &.{ 1, 3, 5, 7, 9 }, 5); // Some(2)
+/// lo.binarySearch(i32, &.{ 1, 3, 5, 7, 9 }, 4); // null
+/// ```
+pub fn binarySearch(comptime T: type, slice: []const T, target: T) ?usize {
+    return binarySearchBy(T, slice, target, struct {
+        fn cmp(a: T, b: T) std.math.Order {
+            return std.math.order(a, b);
+        }
+    }.cmp);
+}
+
+/// Binary search with a custom comparator. Returns the index of the target, or null.
+/// The slice must be sorted according to the comparator.
+///
+/// ```zig
+/// lo.binarySearchBy(Person, &people, target, Person.compareByName);
+/// ```
+pub fn binarySearchBy(
+    comptime T: type,
+    slice: []const T,
+    target: T,
+    comparator: *const fn (T, T) std.math.Order,
+) ?usize {
+    var lo_idx: usize = 0;
+    var hi_idx: usize = slice.len;
+    while (lo_idx < hi_idx) {
+        const mid = lo_idx + (hi_idx - lo_idx) / 2;
+        switch (comparator(slice[mid], target)) {
+            .eq => return mid,
+            .lt => lo_idx = mid + 1,
+            .gt => hi_idx = mid,
+        }
+    }
+    return null;
+}
+
+/// Returns the index of the first element >= `target` in a sorted slice.
+/// Returns `slice.len` if all elements are less than `target`.
+///
+/// ```zig
+/// lo.lowerBound(i32, &.{ 1, 3, 5, 7 }, 4); // 2
+/// lo.lowerBound(i32, &.{ 1, 3, 5, 7 }, 5); // 2
+/// lo.lowerBound(i32, &.{ 1, 3, 5, 7 }, 0); // 0
+/// lo.lowerBound(i32, &.{ 1, 3, 5, 7 }, 9); // 4
+/// ```
+pub fn lowerBound(comptime T: type, slice: []const T, target: T) usize {
+    var lo_idx: usize = 0;
+    var hi_idx: usize = slice.len;
+    while (lo_idx < hi_idx) {
+        const mid = lo_idx + (hi_idx - lo_idx) / 2;
+        if (std.math.order(slice[mid], target) == .lt) {
+            lo_idx = mid + 1;
+        } else {
+            hi_idx = mid;
+        }
+    }
+    return lo_idx;
+}
+
+/// Returns the index of the first element > `target` in a sorted slice.
+/// Returns `slice.len` if all elements are <= `target`.
+///
+/// ```zig
+/// lo.upperBound(i32, &.{ 1, 3, 5, 7 }, 3); // 2
+/// lo.upperBound(i32, &.{ 1, 3, 5, 7 }, 4); // 2
+/// lo.upperBound(i32, &.{ 1, 3, 5, 7 }, 0); // 0
+/// lo.upperBound(i32, &.{ 1, 3, 5, 7 }, 9); // 4
+/// ```
+pub fn upperBound(comptime T: type, slice: []const T, target: T) usize {
+    var lo_idx: usize = 0;
+    var hi_idx: usize = slice.len;
+    while (lo_idx < hi_idx) {
+        const mid = lo_idx + (hi_idx - lo_idx) / 2;
+        if (std.math.order(slice[mid], target) != .gt) {
+            lo_idx = mid + 1;
+        } else {
+            hi_idx = mid;
+        }
+    }
+    return lo_idx;
+}
+
+/// Returns the index where `value` should be inserted into a sorted slice
+/// to maintain order. Equivalent to `lowerBound`.
+///
+/// ```zig
+/// lo.sortedIndex(i32, &.{ 1, 3, 5, 7 }, 4); // 2
+/// lo.sortedIndex(i32, &.{ 1, 3, 5, 7 }, 5); // 2
+/// ```
+pub fn sortedIndex(comptime T: type, slice: []const T, value: T) usize {
+    return lowerBound(T, slice, value);
+}
+
+/// Returns the index after the last occurrence of `value` in a sorted slice.
+/// This is the insertion point that would go *after* existing copies of `value`.
+/// Equivalent to `upperBound`.
+///
+/// ```zig
+/// lo.sortedLastIndex(i32, &.{ 1, 3, 3, 5 }, 3); // 3
+/// lo.sortedLastIndex(i32, &.{ 1, 3, 5, 7 }, 4); // 2
+/// ```
+pub fn sortedLastIndex(comptime T: type, slice: []const T, value: T) usize {
+    return upperBound(T, slice, value);
+}
+
+// Set operations with custom equality.
+
+/// Elements in the first slice but not in the second, using a custom equality predicate.
+///
+/// ```zig
+/// const d = try lo.differenceWith(i32, allocator, &.{1, 2, 3}, &.{2, 4}, eq);
+/// defer allocator.free(d);
+/// // d == &.{1, 3}
+/// ```
+pub fn differenceWith(
+    comptime T: type,
+    allocator: Allocator,
+    a: []const T,
+    b: []const T,
+    predicate: *const fn (T, T) bool,
+) Allocator.Error![]T {
+    var list = std.ArrayList(T){};
+    errdefer list.deinit(allocator);
+    outer: for (a) |item| {
+        for (b) |ex| {
+            if (predicate(item, ex)) continue :outer;
+        }
+        try list.append(allocator, item);
+    }
+    return list.toOwnedSlice(allocator);
+}
+
+/// Elements present in both slices, using a custom equality predicate.
+///
+/// ```zig
+/// const i = try lo.intersectWith(i32, allocator, &.{1, 2, 3}, &.{2, 4}, eq);
+/// defer allocator.free(i);
+/// // i == &.{2}
+/// ```
+pub fn intersectWith(
+    comptime T: type,
+    allocator: Allocator,
+    a: []const T,
+    b: []const T,
+    predicate: *const fn (T, T) bool,
+) Allocator.Error![]T {
+    var list = std.ArrayList(T){};
+    errdefer list.deinit(allocator);
+    for (a) |item| {
+        for (b) |candidate| {
+            if (predicate(item, candidate)) {
+                try list.append(allocator, item);
+                break;
+            }
+        }
+    }
+    return list.toOwnedSlice(allocator);
+}
+
+/// Unique elements from both slices combined, using a custom equality predicate.
+///
+/// ```zig
+/// const u = try lo.unionWith(i32, allocator, &.{1, 2}, &.{2, 3}, eq);
+/// defer allocator.free(u);
+/// // u == &.{1, 2, 3}
+/// ```
+pub fn unionWith(
+    comptime T: type,
+    allocator: Allocator,
+    a: []const T,
+    b: []const T,
+    predicate: *const fn (T, T) bool,
+) Allocator.Error![]T {
+    var list = std.ArrayList(T){};
+    errdefer list.deinit(allocator);
+    for (a) |item| try list.append(allocator, item);
+    for (b) |item| {
+        var found = false;
+        for (list.items) |existing| {
+            if (predicate(item, existing)) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) try list.append(allocator, item);
+    }
+    return list.toOwnedSlice(allocator);
+}
+
+/// Filter and map in a single pass. Applies `transform` to each element;
+/// if it returns a non-null value, that value is included in the result.
+/// The known output size is the input size, so a single allocation suffices.
+/// Caller owns the returned slice.
+///
+/// ```zig
+/// const result = try lo.compactMap(i32, u8, allocator, &.{1, 2, 3}, toCharIfSmall);
+/// defer allocator.free(result);
+/// ```
+pub fn compactMap(
+    comptime T: type,
+    comptime R: type,
+    allocator: Allocator,
+    slice: []const T,
+    transform: *const fn (T) ?R,
+) Allocator.Error![]R {
+    var list = std.ArrayList(R){};
+    errdefer list.deinit(allocator);
+    for (slice) |item| {
+        if (transform(item)) |val| {
+            try list.append(allocator, val);
+        }
+    }
+    return list.toOwnedSlice(allocator);
+}
+
+/// Lazy iterator that filters and maps in a single step.
+/// Returned by `filterMap()`. See `filterMap()` for usage examples.
+pub fn FilterMapIterator(comptime T: type, comptime R: type) type {
+    return struct {
+        slice: []const T,
+        transform: *const fn (T) ?R,
+        index: usize = 0,
+
+        const Self = @This();
+
+        pub fn next(self: *Self) ?R {
+            while (self.index < self.slice.len) {
+                const item = self.slice[self.index];
+                self.index += 1;
+                if (self.transform(item)) |val| return val;
+            }
+            return null;
+        }
+
+        pub fn collect(self: *Self, allocator: Allocator) Allocator.Error![]R {
+            var list = std.ArrayList(R){};
+            errdefer list.deinit(allocator);
+            while (self.next()) |item| {
+                try list.append(allocator, item);
+            }
+            return list.toOwnedSlice(allocator);
+        }
+    };
+}
+
+/// Filter and map in a single step. Returns a lazy iterator.
+///
+/// ```zig
+/// var it = lo.filterMap(i32, u8, &.{ 1, 2, 3 }, toCharIfSmall);
+/// it.next(); // filtered+mapped value
+/// ```
+pub fn filterMapIter(
+    comptime T: type,
+    comptime R: type,
+    slice: []const T,
+    transform: *const fn (T) ?R,
+) FilterMapIterator(T, R) {
+    return .{ .slice = slice, .transform = transform };
 }
 
 // Tests: Element access.
@@ -2421,6 +2776,28 @@ test "dropWhile: none match returns whole slice" {
     try std.testing.expectEqualSlices(i32, &.{ 1, 2, 3 }, result);
 }
 
+test "dropWhileAlloc: allocates result" {
+    const lessThan3 = struct {
+        fn f(x: i32) bool {
+            return x < 3;
+        }
+    }.f;
+    const result = try dropWhileAlloc(i32, std.testing.allocator, &.{ 1, 2, 3, 4 }, lessThan3);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualSlices(i32, &.{ 3, 4 }, result);
+}
+
+test "dropWhileAlloc: empty input" {
+    const always = struct {
+        fn f(_: i32) bool {
+            return true;
+        }
+    }.f;
+    const result = try dropWhileAlloc(i32, std.testing.allocator, &.{}, always);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqual(@as(usize, 0), result.len);
+}
+
 test "dropRightWhile: drops from right" {
     const gt2 = struct {
         fn f(x: i32) bool {
@@ -2508,6 +2885,28 @@ test "takeWhile: none match returns empty" {
         }
     }.f;
     const result = takeWhile(i32, &.{ 1, 2, 3 }, never);
+    try std.testing.expectEqual(@as(usize, 0), result.len);
+}
+
+test "takeWhileAlloc: allocates result" {
+    const lessThan3 = struct {
+        fn f(x: i32) bool {
+            return x < 3;
+        }
+    }.f;
+    const result = try takeWhileAlloc(i32, std.testing.allocator, &.{ 1, 2, 3, 4 }, lessThan3);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualSlices(i32, &.{ 1, 2 }, result);
+}
+
+test "takeWhileAlloc: empty input" {
+    const always = struct {
+        fn f(_: i32) bool {
+            return true;
+        }
+    }.f;
+    const result = try takeWhileAlloc(i32, std.testing.allocator, &.{}, always);
+    defer std.testing.allocator.free(result);
     try std.testing.expectEqual(@as(usize, 0), result.len);
 }
 
@@ -3079,6 +3478,56 @@ test "flattenAlloc: allocated result" {
     try std.testing.expectEqualSlices(i32, &.{ 1, 2, 3, 4 }, result);
 }
 
+test "flattenAlloc: different length slices" {
+    const a = [_]i32{ 1, 2 };
+    const b = [_]i32{ 3, 4, 5 };
+    const slices = [_][]const i32{ &a, &b };
+    const result = try flattenAlloc(i32, std.testing.allocator, &slices);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualSlices(i32, &.{ 1, 2, 3, 4, 5 }, result);
+}
+
+test "flattenAlloc: empty input" {
+    const slices = [_][]const i32{};
+    const result = try flattenAlloc(i32, std.testing.allocator, &slices);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqual(@as(usize, 0), result.len);
+}
+
+test "flattenAlloc: mixed empty and non-empty" {
+    const a = [_]i32{1};
+    const b = [_]i32{};
+    const c = [_]i32{ 2, 3 };
+    const slices = [_][]const i32{ &a, &b, &c };
+    const result = try flattenAlloc(i32, std.testing.allocator, &slices);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualSlices(i32, &.{ 1, 2, 3 }, result);
+}
+
+test "flattenDeep: two levels of nesting" {
+    const inner1 = [_][]const i32{ &.{ 1, 2 }, &.{3} };
+    const inner2 = [_][]const i32{&.{ 4, 5, 6 }};
+    const outer = [_][]const []const i32{ &inner1, &inner2 };
+    const result = try flattenDeep(i32, std.testing.allocator, &outer);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualSlices(i32, &.{ 1, 2, 3, 4, 5, 6 }, result);
+}
+
+test "flattenDeep: single inner" {
+    const inner = [_][]const i32{&.{ 10, 20 }};
+    const outer = [_][]const []const i32{&inner};
+    const result = try flattenDeep(i32, std.testing.allocator, &outer);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualSlices(i32, &.{ 10, 20 }, result);
+}
+
+test "flattenDeep: empty outer" {
+    const outer = [_][]const []const i32{};
+    const result = try flattenDeep(i32, std.testing.allocator, &outer);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqual(@as(usize, 0), result.len);
+}
+
 test "flatMap: map then flatten" {
     // Map each i32 to a pair of itself repeated
     const Pairs = struct {
@@ -3170,6 +3619,11 @@ test "chunk: empty slice" {
 test "chunk: size larger than slice" {
     var it = chunk(i32, &.{ 1, 2 }, 10);
     try std.testing.expectEqualSlices(i32, &.{ 1, 2 }, it.next().?);
+    try std.testing.expectEqual(@as(?[]const i32, null), it.next());
+}
+
+test "chunk: zero size returns null" {
+    var it = chunk(i32, &.{ 1, 2, 3 }, 0);
     try std.testing.expectEqual(@as(?[]const i32, null), it.next());
 }
 
@@ -4640,4 +5094,276 @@ test "timesAlloc: n=0 returns empty" {
     const result = try timesAlloc(usize, std.testing.allocator, 0, identity);
     defer std.testing.allocator.free(result);
     try std.testing.expectEqual(@as(usize, 0), result.len);
+}
+
+// Tests: Binary search.
+
+test "binarySearch: finds existing element" {
+    try std.testing.expectEqual(@as(?usize, 2), binarySearch(i32, &.{ 1, 3, 5, 7, 9 }, 5));
+}
+
+test "binarySearch: returns null for missing element" {
+    try std.testing.expectEqual(@as(?usize, null), binarySearch(i32, &.{ 1, 3, 5, 7, 9 }, 4));
+}
+
+test "binarySearch: first element" {
+    try std.testing.expectEqual(@as(?usize, 0), binarySearch(i32, &.{ 1, 3, 5 }, 1));
+}
+
+test "binarySearch: last element" {
+    try std.testing.expectEqual(@as(?usize, 2), binarySearch(i32, &.{ 1, 3, 5 }, 5));
+}
+
+test "binarySearch: single element found" {
+    try std.testing.expectEqual(@as(?usize, 0), binarySearch(i32, &.{42}, 42));
+}
+
+test "binarySearch: single element not found" {
+    try std.testing.expectEqual(@as(?usize, null), binarySearch(i32, &.{42}, 0));
+}
+
+test "binarySearch: empty slice" {
+    try std.testing.expectEqual(@as(?usize, null), binarySearch(i32, &.{}, 1));
+}
+
+test "binarySearch: with duplicates returns one of them" {
+    const result = binarySearch(i32, &.{ 1, 3, 3, 3, 5 }, 3).?;
+    try std.testing.expect(result >= 1 and result <= 3);
+}
+
+test "lowerBound: finds insertion point" {
+    try std.testing.expectEqual(@as(usize, 2), lowerBound(i32, &.{ 1, 3, 5, 7 }, 4));
+}
+
+test "lowerBound: target matches existing" {
+    try std.testing.expectEqual(@as(usize, 2), lowerBound(i32, &.{ 1, 3, 5, 7 }, 5));
+}
+
+test "lowerBound: before all elements" {
+    try std.testing.expectEqual(@as(usize, 0), lowerBound(i32, &.{ 1, 3, 5 }, 0));
+}
+
+test "lowerBound: after all elements" {
+    try std.testing.expectEqual(@as(usize, 4), lowerBound(i32, &.{ 1, 3, 5, 7 }, 9));
+}
+
+test "lowerBound: empty slice" {
+    try std.testing.expectEqual(@as(usize, 0), lowerBound(i32, &.{}, 1));
+}
+
+test "lowerBound: duplicates returns first" {
+    try std.testing.expectEqual(@as(usize, 1), lowerBound(i32, &.{ 1, 3, 3, 3, 5 }, 3));
+}
+
+test "upperBound: finds insertion point after" {
+    try std.testing.expectEqual(@as(usize, 2), upperBound(i32, &.{ 1, 3, 5, 7 }, 3));
+}
+
+test "upperBound: target between elements" {
+    try std.testing.expectEqual(@as(usize, 2), upperBound(i32, &.{ 1, 3, 5, 7 }, 4));
+}
+
+test "upperBound: before all elements" {
+    try std.testing.expectEqual(@as(usize, 0), upperBound(i32, &.{ 1, 3, 5 }, 0));
+}
+
+test "upperBound: after all elements" {
+    try std.testing.expectEqual(@as(usize, 4), upperBound(i32, &.{ 1, 3, 5, 7 }, 9));
+}
+
+test "upperBound: duplicates returns after last" {
+    try std.testing.expectEqual(@as(usize, 4), upperBound(i32, &.{ 1, 3, 3, 3, 5 }, 3));
+}
+
+test "upperBound: empty slice" {
+    try std.testing.expectEqual(@as(usize, 0), upperBound(i32, &.{}, 1));
+}
+
+test "sortedIndex: insertion point" {
+    try std.testing.expectEqual(@as(usize, 2), sortedIndex(i32, &.{ 1, 3, 5, 7 }, 4));
+}
+
+test "sortedIndex: at beginning" {
+    try std.testing.expectEqual(@as(usize, 0), sortedIndex(i32, &.{ 3, 5, 7 }, 1));
+}
+
+test "sortedIndex: at end" {
+    try std.testing.expectEqual(@as(usize, 3), sortedIndex(i32, &.{ 1, 3, 5 }, 7));
+}
+
+test "sortedLastIndex: after duplicates" {
+    try std.testing.expectEqual(@as(usize, 3), sortedLastIndex(i32, &.{ 1, 3, 3, 5 }, 3));
+}
+
+test "sortedLastIndex: no duplicates" {
+    try std.testing.expectEqual(@as(usize, 2), sortedLastIndex(i32, &.{ 1, 3, 5, 7 }, 4));
+}
+
+// Tests: Set operations with custom equality.
+
+const absEqual = struct {
+    fn f(a: i32, b: i32) bool {
+        return @abs(a) == @abs(b);
+    }
+}.f;
+
+test "differenceWith: basic" {
+    const result = try differenceWith(i32, std.testing.allocator, &.{ 1, 2, 3 }, &.{ 2, 4 }, absEqual);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualSlices(i32, &.{ 1, 3 }, result);
+}
+
+test "differenceWith: with negative matching" {
+    const result = try differenceWith(i32, std.testing.allocator, &.{ 1, 2, 3 }, &.{ -2, 4 }, absEqual);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualSlices(i32, &.{ 1, 3 }, result);
+}
+
+test "differenceWith: all removed" {
+    const result = try differenceWith(i32, std.testing.allocator, &.{ 1, 2 }, &.{ 1, 2 }, absEqual);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqual(@as(usize, 0), result.len);
+}
+
+test "differenceWith: empty a" {
+    const result = try differenceWith(i32, std.testing.allocator, &.{}, &.{ 1, 2 }, absEqual);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqual(@as(usize, 0), result.len);
+}
+
+test "intersectWith: basic" {
+    const result = try intersectWith(i32, std.testing.allocator, &.{ 1, 2, 3 }, &.{ 2, 4 }, absEqual);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualSlices(i32, &.{2}, result);
+}
+
+test "intersectWith: with negative matching" {
+    const result = try intersectWith(i32, std.testing.allocator, &.{ 1, -2, 3 }, &.{ 2, 4 }, absEqual);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualSlices(i32, &.{-2}, result);
+}
+
+test "intersectWith: no overlap" {
+    const result = try intersectWith(i32, std.testing.allocator, &.{ 1, 2 }, &.{ 3, 4 }, absEqual);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqual(@as(usize, 0), result.len);
+}
+
+test "unionWith: basic" {
+    const result = try unionWith(i32, std.testing.allocator, &.{ 1, 2 }, &.{ 2, 3 }, absEqual);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualSlices(i32, &.{ 1, 2, 3 }, result);
+}
+
+test "unionWith: negative deduplication" {
+    const result = try unionWith(i32, std.testing.allocator, &.{ 1, 2 }, &.{ -2, 3 }, absEqual);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualSlices(i32, &.{ 1, 2, 3 }, result);
+}
+
+test "unionWith: disjoint" {
+    const result = try unionWith(i32, std.testing.allocator, &.{ 1, 2 }, &.{ 3, 4 }, absEqual);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualSlices(i32, &.{ 1, 2, 3, 4 }, result);
+}
+
+// Tests: compactMap.
+
+test "compactMap: filters and maps" {
+    const toEvenDoubled = struct {
+        fn f(x: i32) ?i32 {
+            if (@mod(x, 2) == 0) return x * 2;
+            return null;
+        }
+    }.f;
+    const result = try compactMap(i32, i32, std.testing.allocator, &.{ 1, 2, 3, 4, 5 }, toEvenDoubled);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualSlices(i32, &.{ 4, 8 }, result);
+}
+
+test "compactMap: all filtered out" {
+    const always_null = struct {
+        fn f(_: i32) ?i32 {
+            return null;
+        }
+    }.f;
+    const result = try compactMap(i32, i32, std.testing.allocator, &.{ 1, 2, 3 }, always_null);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqual(@as(usize, 0), result.len);
+}
+
+test "compactMap: all kept" {
+    const identity = struct {
+        fn f(x: i32) ?i32 {
+            return x;
+        }
+    }.f;
+    const result = try compactMap(i32, i32, std.testing.allocator, &.{ 1, 2, 3 }, identity);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualSlices(i32, &.{ 1, 2, 3 }, result);
+}
+
+test "compactMap: empty input" {
+    const identity = struct {
+        fn f(x: i32) ?i32 {
+            return x;
+        }
+    }.f;
+    const result = try compactMap(i32, i32, std.testing.allocator, &.{}, identity);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqual(@as(usize, 0), result.len);
+}
+
+test "compactMap: type change" {
+    const toStr = struct {
+        const strs = [_][]const u8{ "zero", "one", "two" };
+        fn f(x: i32) ?[]const u8 {
+            if (x >= 0 and x < strs.len) return strs[@intCast(x)];
+            return null;
+        }
+    }.f;
+    const result = try compactMap(i32, []const u8, std.testing.allocator, &.{ 0, 3, 1, 2 }, toStr);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqual(@as(usize, 3), result.len);
+    try std.testing.expectEqualStrings("zero", result[0]);
+    try std.testing.expectEqualStrings("one", result[1]);
+    try std.testing.expectEqualStrings("two", result[2]);
+}
+
+// Tests: filterMapIter.
+
+test "filterMapIter: lazy filter+map" {
+    const toEvenDoubled = struct {
+        fn f(x: i32) ?i32 {
+            if (@mod(x, 2) == 0) return x * 2;
+            return null;
+        }
+    }.f;
+    var it = filterMapIter(i32, i32, &.{ 1, 2, 3, 4, 5 }, toEvenDoubled);
+    try std.testing.expectEqual(@as(?i32, 4), it.next());
+    try std.testing.expectEqual(@as(?i32, 8), it.next());
+    try std.testing.expectEqual(@as(?i32, null), it.next());
+}
+
+test "filterMapIter: collect" {
+    const toOptional = struct {
+        fn f(x: i32) ?i32 {
+            if (x > 2) return x;
+            return null;
+        }
+    }.f;
+    var it = filterMapIter(i32, i32, &.{ 1, 2, 3, 4 }, toOptional);
+    const result = try it.collect(std.testing.allocator);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualSlices(i32, &.{ 3, 4 }, result);
+}
+
+test "filterMapIter: empty input" {
+    const identity = struct {
+        fn f(x: i32) ?i32 {
+            return x;
+        }
+    }.f;
+    var it = filterMapIter(i32, i32, &.{}, identity);
+    try std.testing.expectEqual(@as(?i32, null), it.next());
 }

--- a/src/types.zig
+++ b/src/types.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 
-
 /// DISCLAIMER: This shit is experimental, needed in another project - with Zig monads
-
 /// Returns true if the optional value is null.
 ///
 /// ```zig
@@ -64,7 +62,7 @@ pub fn empty(comptime T: type) T {
         .bool => false,
         .optional => null,
         .null => null,
-        .@"enum" => @enumFromInt(0),
+        .@"enum" => @enumFromInt(@typeInfo(T).@"enum".fields[0].value),
         .@"struct" => std.mem.zeroes(T),
         .array => std.mem.zeroes(T),
         .vector => std.mem.zeroes(T),
@@ -212,6 +210,16 @@ test "empty: bool false" {
 
 test "empty: optional null" {
     try std.testing.expectEqual(@as(?i32, null), empty(?i32));
+}
+
+test "empty: enum returns first variant" {
+    const E = enum { a, b, c };
+    try std.testing.expectEqual(E.a, empty(E));
+}
+
+test "empty: enum with non-zero start returns first variant" {
+    const E = enum(u8) { x = 10, y = 20, z = 30 };
+    try std.testing.expectEqual(E.x, empty(E));
 }
 
 test "isEmpty: zero integer is empty" {


### PR DESCRIPTION
- Fixed: chunk size=0, sortBy/sortByField comparison, empty for enums